### PR TITLE
ヘルプページを一時的に無効にする

### DIFF
--- a/svelte/src/routes/Header.svelte
+++ b/svelte/src/routes/Header.svelte
@@ -42,6 +42,8 @@
         background-color: var(--bg-color-secondary);
     }
     #help {
+        display: none;
+
         border: 1px solid var(--text-color-primary);
         border-radius: 4px;
         padding: 8px 16px;
@@ -50,6 +52,8 @@
         text-align: center;
     }
     .help_btn {
+        display: none;
+
         border: none;
         padding: 8px 12px;
         border-radius: 50%;


### PR DESCRIPTION
close #20 
popoverのブラウザ対応が完全ではない為一時的に無効にする
[popover](https://developer.mozilla.org/ja/docs/Web/HTML/Global_attributes/popover)
サインアップとログイン画面で表示しているのでトップページでは必要なさそう